### PR TITLE
`set_password` now calls `set_unusable_password` if no password is given.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.sw[po]
 pip-log.txt
 .DS_Store
+*.egg-info

--- a/django_sha2/auth.py
+++ b/django_sha2/auth.py
@@ -44,6 +44,9 @@ def monkeypatch():
 
 
     def set_password(self, raw_password):
+        if raw_password is None:
+            self.set_unusable_password()
+            return
         if algo != 'bcrypt':
             salt = os.urandom(10).encode('hex')  # Random, 20-digit (hex) salt.
             hsh = get_hexdigest(algo, salt, raw_password)


### PR DESCRIPTION
`set_password` now calls `set_unusable_password` if no password is given.

Prior to this patch, `set_password` raises a TypeError if no password
is given to it. This conflicts with the behavior of
`django.contrib.auth`. This patch fixes that.
