### PR TITLE
Call int() on rounds before passing to bcrypt.gensalt()

### DIFF
--- a/django_sha2/bcrypt_auth.py
+++ b/django_sha2/bcrypt_auth.py
@@ -46,7 +46,7 @@ def _bcrypt_create(hmac_value):
     """Create bcrypt hash."""
     rounds = getattr(settings, 'BCRYPT_ROUNDS', 12)
     # No need for us to create a user salt, bcrypt creates its own.
-    bcrypt_value = bcrypt.hashpw(hmac_value, bcrypt.gensalt(rounds))
+    bcrypt_value = bcrypt.hashpw(hmac_value, bcrypt.gensalt(int(rounds)))
     return bcrypt_value
 
 


### PR DESCRIPTION
bcrypt.gensalt() will gladly accept a string value, however it will always generate a salt with a work factor of 31. I ran into this issue when I inadvertently put BCRYPT_ROUNDS = '12' instead of ...= 12 in my settings.py.
