### PR TITLE
Fix for unicode password and/or shared_key

### DIFF
--- a/django_sha2/bcrypt_auth.py
+++ b/django_sha2/bcrypt_auth.py
@@ -6,6 +6,7 @@ import bcrypt
 import hmac
 
 from django.conf import settings
+from django.utils.encoding import smart_str
 
 
 def create_hash(userpwd):
@@ -38,7 +39,7 @@ def check_password(db_entry, raw_pass):
 def _hmac_create(userpwd, shared_key):
     """Create HMAC value based on pwd and system-local and per-user salt."""
     hmac_value = base64.b64encode(hmac.new(
-        shared_key, userpwd, hashlib.sha512).digest())
+        smart_str(shared_key), smart_str(userpwd), hashlib.sha512).digest())
     return hmac_value
 
 

--- a/django_sha2/tests/test_bcrypt.py
+++ b/django_sha2/tests/test_bcrypt.py
@@ -1,3 +1,4 @@
+# -*- coding:utf-8 -*-
 from django import test
 from django.conf import settings
 from django.contrib.auth import authenticate
@@ -14,17 +15,22 @@ class BcryptTests(test.TestCase):
                                  password='123456')
         User.objects.create_user('jane', 'janedoe@example.com',
                                  password='abc')
+        User.objects.create_user('jude', 'jeromedoe@example.com',
+                                 password=u'abcéäêëôøà')                                 
 
     def test_bcrypt_used(self):
         """Make sure bcrypt was used as the hash."""
-        john = User.objects.get(username='john')
-        eq_(john.password[:6], 'bcrypt')
+        eq_(User.objects.get(username='john').password[:6], 'bcrypt')
+        eq_(User.objects.get(username='jane').password[:6], 'bcrypt')
+        eq_(User.objects.get(username='jude').password[:6], 'bcrypt')
 
     def test_bcrypt_auth(self):
         """Try authenticating."""
         assert authenticate(username='john', password='123456')
         assert authenticate(username='jane', password='abc')
         assert not authenticate(username='jane', password='123456')
+        assert authenticate(username='jude', password=u'abcéäêëôøà')
+        assert not authenticate(username='jude', password=u'çççbbbààà')
 
     @patch.object(settings._wrapped, 'HMAC_KEYS', dict())
     def test_nokey(self):
@@ -32,3 +38,5 @@ class BcryptTests(test.TestCase):
         assert not authenticate(username='john', password='123456')
         assert not authenticate(username='jane', password='abc')
         assert not authenticate(username='jane', password='123456')
+        assert not authenticate(username='jude', password=u'abcéäêëôøà')
+        assert not authenticate(username='jude', password=u'çççbbbààà')


### PR DESCRIPTION
Currently django_sha2 fails with unicode passwords when bcrypt auth scheme is chosen. These 2 commits fix the issue and add basic tests.
